### PR TITLE
Ease pain on MD

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
                     "description": "Glob patterns to match files that should have auto formatting enabled",
                     "default": {
                         "csv": ",",
-                        "bsv": "|"
+                        "bsv": "|",
+                        "md": "|"
                     }
                 },
                 "autoAlign.delay": {


### PR DESCRIPTION
# Problem
Get confused by not working on MD after enabling "auto align" .
This may confuse some user.
# Predict 
Enable on MD after installation or after enable for MD lang.

# What I did 
Add default separator "|" for MD.

> Thanks a lot 💘 
> Enjoying it so much with *fcrespo82.markdown-table-formatter* (move column functions)